### PR TITLE
.Net Core problem on gVisor was fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,8 +259,7 @@ If an application can be packaged into a container image that can run on Linux
 (x86-64), it can be executed on Cloud Run.
 
 Web applications written in languages like Node.js, Python, Go, Java, Ruby, PHP,
-Rust, Kotlin, Swift, C/C++ can work on Cloud Run. _(.NET Core is currently
-not supported due to a bug.)_
+Rust, Kotlin, Swift, C/C++, C# can work on Cloud Run. 
 
 🍄 Users managed to run web servers written in x86 assembly, or [22-year old
 Python


### PR DESCRIPTION
I confirmed C# using .NET Core 2.2 worked properly. So, we can use C# now 🎉 

With this image
[gcr.io/knative-samples/helloworld-csharp](https://console.cloud.google.com/gcr/images/knative-samples/GLOBAL/helloworld-csharp?gcrImageListsize=30)

<img width="870" alt="スクリーンショット_2019-05-15_22_58_07" src="https://user-images.githubusercontent.com/7035446/57786736-01654500-776f-11e9-84c1-cfe964ac2f5c.png">

