### PR TITLE
Remove Cloudflare as a CDN solution.

### DIFF
--- a/README.md
+++ b/README.md
@@ -695,9 +695,6 @@ However, you can have CDN from other services:
     `firebase.json`](https://firebase.google.com/docs/hosting/cloud-run#direct_requests_to_container)
     of your Firebase app.
 
-- [Cloudflare](https://cloudflare.com/) (not Google) using a custom domain
-  mapping.
-
 ### Does Cloud Run offer SSL/TLS certificates (HTTPS)?
 
 Yes. If you’re using the domain name provided by Cloud Run (`*.run.app`), your


### PR DESCRIPTION
Cloud Run managed certs can't renew if Cloudflare's proxy/CDN is enabled. 
Perhaps due to failing DNS challenge?