### PR TITLE
Update default value for concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -704,7 +704,7 @@ requests to be handled
 your container instances.
 
 Each container instance on Cloud Run is (currently) allowed to handle [up to
-250][lim] concurrent requests. This is also the default value.
+250][lim] concurrent requests. The [default](https://cloud.google.com/run/docs/about-concurrency#concurrency_values) is 80.
 
 ### What if my application can’t handle concurrent requests?
 


### PR DESCRIPTION
Thank you for this awesome resource.  I believe the default value for concurrency is out of date - the referenced doc state "By default each Cloud Run container instance can receive up to 80 requests at the same time..." 

Thanks! 