### PR TITLE
Update max value for concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -704,7 +704,7 @@ requests to be handled
 your container instances.
 
 Each container instance on Cloud Run is (currently) allowed to handle [up to
-250][lim] concurrent requests. The [default](https://cloud.google.com/run/docs/about-concurrency#concurrency_values) is 80.
+1000][lim] concurrent requests. The [default](https://cloud.google.com/run/docs/about-concurrency#concurrency_values) is 80.
 
 ### What if my application can’t handle concurrent requests?
 


### PR DESCRIPTION
Thanks for this helpful guide to Cloud Run. The max concurrency value for Cloud Run has apparently been bumped from 250 to 1000 now, while the default remains the same as before (80).