### PR TITLE
Update README.md to reflect updated timeout information

### DIFF
--- a/README.md
+++ b/README.md
@@ -659,8 +659,7 @@ Cloud Run. (Upon customizing, `PORT` value will have the specified value.)
 
 ### What's the maximum request execution time limit?
 
-Currently, a request times out after **15 minutes**. See [limits][lim].
-(60-minute request timeouts are currently in preview.)
+Currently, a request times out after **5 minutes** but can be configured up to 60 minutes. See [limits][lim].
 
 ### Does my service get a domain name on Cloud Run?
 

--- a/README.md
+++ b/README.md
@@ -659,7 +659,7 @@ Cloud Run. (Upon customizing, `PORT` value will have the specified value.)
 
 ### What's the maximum request execution time limit?
 
-Currently, a request times out after **5 minutes** but can be configured up to 60 minutes. See [limits][lim].
+By default 5 minutes or up to 60 minutes, if configured. See [limits][lim].
 
 ### Does my service get a domain name on Cloud Run?
 


### PR DESCRIPTION
Default is five minutes, see: https://cloud.google.com/run/docs/configuring/request-timeout#yaml

Maximum of 60 minutes is GA, see: https://cloud.google.com/run/docs/release-notes#June_03_2021
