### PR TITLE
Fix Knative Serving API broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ yourself.
 Sort of.
 
 Cloud Run implements most parts of the [Knative Serving
-API](https://www.knative.dev/docs/reference/serving-api/). However, the
+API](https://knative.dev/docs/reference/api/serving-api/). However, the
 underlying implementation of the functionality could differ from the open source
 [Knative][knative] implementation.
 


### PR DESCRIPTION
Link in the README for this section leads to a Netlify Page Not Found message.

> Cloud Run implements most parts of the [Knative Serving API](https://knative.dev/docs/reference/serving-api/). However, the underlying implementation of the functionality could differ from the open source [Knative][knative] implementation.

Current link is now: https://knative.dev/docs/reference/api/serving-api/

Also, I didn't include a fix for this because I'm not sure what the video is supposed to be, but the video link here goes to a private YouTube video:

> Look at [this diagram](https://twitter.com/ahmetb/status/1116041166359654400), or [**watch this video**](https://www.youtube.com/watch?v=RVdhyprptTQ) to decide how to choose between the two.

*Side note: Excellent work on this repo!! 🙌*